### PR TITLE
Initial implementation of OpenWeather weather provider

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,7 @@ dependencies = [
  "libc",
  "num-integer",
  "num-traits",
+ "serde",
  "time",
  "winapi",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,13 @@ path = "src/main.rs"
 
 [dependencies]
 anyhow = "1.0"
-chrono = "0.4"
+chrono = { version = "0.4", features = ["serde"] }
 chrono-tz = "0.5"
 clap = "2.33"
 fern = "0.6"
 lambda_runtime = "0.4"
 log = "0.4"
 reqwest = { version = "0.11", features = ["gzip", "json"] }
-serde = "1.0"
+serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 tokio = { version = "1.11", features = ["full"] }

--- a/src/alexa.rs
+++ b/src/alexa.rs
@@ -61,15 +61,9 @@ fn speakable_timestamp(timestamp: &DateTime<Tz>) -> String {
 }
 
 fn speakable_weather(weather: &Weather) -> String {
-    let forecast = if "drizzle".eq_ignore_ascii_case(&weather.summary) {
-        "Drizzling"
-    } else {
-        weather.summary.as_str()
-    };
-
     format!(
         "{:.0} and {}",
         weather.apparent_temp.unwrap_or(weather.temp),
-        forecast
+        weather.summary
     )
 }

--- a/src/weather/dark_sky.rs
+++ b/src/weather/dark_sky.rs
@@ -18,6 +18,12 @@ impl TryFrom<(DateTime<Tz>, &Value)> for Weather {
             .ok_or_else(|| anyhow!("Missing weather summary"))?
             .to_owned();
 
+        let summary = if "drizzle".eq_ignore_ascii_case(&summary) {
+            "Drizzling".into()
+        } else {
+            summary
+        };
+
         let temp = dark_sky_data["temperature"]
             .as_f64()
             .ok_or_else(|| anyhow!("Missing temperature"))?;
@@ -51,6 +57,7 @@ pub async fn query(dark_sky_api_key: String, latitude: f64, longitude: f64) -> R
         .headers(headers)
         .send()
         .await?
+        .error_for_status()?
         .text()
         .await?;
 

--- a/src/weather/mod.rs
+++ b/src/weather/mod.rs
@@ -18,6 +18,7 @@ pub struct Weather {
     pub apparent_temp: Option<f64>,
 }
 
+#[derive(Debug)]
 pub enum WeatherProvider {
     DarkSky,
     OpenWeather,
@@ -34,14 +35,14 @@ impl WeatherProvider {
     async fn query(&self, api_key: String, latitude: f64, longitude: f64) -> Result<String> {
         match self {
             Self::DarkSky => dark_sky::query(api_key, latitude, longitude).await,
-            Self::OpenWeather => todo!(),
+            Self::OpenWeather => open_weather::query(api_key, latitude, longitude).await,
         }
     }
 
     async fn parse_weather(&self, response: String) -> Result<Vec<Weather>> {
         match self {
             Self::DarkSky => dark_sky::parse_weather(response).await,
-            Self::OpenWeather => todo!(),
+            Self::OpenWeather => open_weather::parse_weather(response).await,
         }
     }
 }


### PR DESCRIPTION
- Update `main.rs` to allow specifying a provider, use Clap more
  for parsing env vars, etc.
- Move provider-specific weather summary overrides into the
  providers
- Handle errors in HTTP responses