### PR TITLE
Add weather alerts support for OpenWeather

### DIFF
--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -36,9 +36,9 @@ async fn function(event: LambdaEvent<Value>) -> Result<Value, LambdaError> {
     // Validate coordinates
     validate_coordinates(latitude, longitude)?;
 
-    let weather = WeatherProvider::OpenWeather
+    let (weather, alerts) = WeatherProvider::OpenWeather
         .get_weather(false, &api_key, latitude, longitude)
         .await?;
 
-    Ok(alexa::forecast(weather)?)
+    Ok(alexa::forecast(weather, alerts)?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -110,12 +110,12 @@ async fn main() -> Result<()> {
     // Validate coordinates early for better error messages
     validate_coordinates(args.latitude, args.longitude)?;
 
-    let weather = args
+    let (weather, alerts) = args
         .provider
         .get_weather(args.use_cache, &args.api_key, args.latitude, args.longitude)
         .await?;
 
-    alexa::forecast(weather)?;
+    alexa::forecast(weather, alerts)?;
 
     Ok(())
 }

--- a/src/weather/accu_weather.rs
+++ b/src/weather/accu_weather.rs
@@ -229,6 +229,7 @@ pub async fn get_weather(
         timezone: current.timestamp.timezone(),
         current,
         upcoming,
+        alerts: Vec::new(), // AccuWeather doesn't provide alerts
     })
 }
 

--- a/src/weather/accu_weather.rs
+++ b/src/weather/accu_weather.rs
@@ -229,7 +229,7 @@ pub async fn get_weather(
         timezone: current.timestamp.timezone(),
         current,
         upcoming,
-        alerts: Vec::new(), // AccuWeather doesn't provide alerts
+        alerts: Vec::new(), // AccuWeather alerts are not currently implemented
     })
 }
 

--- a/src/weather/mod.rs
+++ b/src/weather/mod.rs
@@ -78,11 +78,21 @@ impl Weather {
     }
 }
 
+#[derive(Debug, Clone)]
+pub struct WeatherAlert {
+    pub event: String,
+    pub sender_name: String,
+    pub start: DateTime<Tz>,
+    pub end: DateTime<Tz>,
+    pub description: String,
+}
+
 #[derive(Debug)]
 pub struct WeatherForecast {
     pub current: Weather,
     pub upcoming: Vec<Weather>,
     pub timezone: Tz,
+    pub alerts: Vec<WeatherAlert>,
 }
 
 #[derive(Debug)]
@@ -105,7 +115,7 @@ impl WeatherProvider {
         api_key: &ApiKey,
         latitude: f64,
         longitude: f64,
-    ) -> Result<Vec<Weather>> {
+    ) -> Result<(Vec<Weather>, Vec<WeatherAlert>)> {
         // Validate coordinates before making API calls
         validate_coordinates(latitude, longitude)
             .with_context(|| format!("Invalid coordinates: lat={latitude}, lon={longitude}"))?;
@@ -121,6 +131,7 @@ impl WeatherProvider {
         debug!("{weather:?}");
 
         let now = Utc::now().with_timezone(&weather.timezone);
+        let alerts = weather.alerts;
 
         let hours_of_interest = hours_of_interest(now, None, false);
 
@@ -145,7 +156,7 @@ impl WeatherProvider {
             }
         }
 
-        Ok(filtered)
+        Ok((filtered, alerts))
     }
 }
 

--- a/src/weather/open_weather.rs
+++ b/src/weather/open_weather.rs
@@ -116,8 +116,8 @@ fn filter_alerts(alerts: Vec<Alert>, timezone: Tz) -> Vec<WeatherAlert> {
             let start = alert.start.with_timezone(&timezone);
             let end = alert.end.with_timezone(&timezone);
 
-            // Include alerts that haven't ended and start within 3 days
-            if end > now && start <= three_days_from_now {
+            // Include alerts that haven't ended, start within 3 days, and have valid duration
+            if end > now && start <= three_days_from_now && start <= end {
                 Some(WeatherAlert {
                     event: alert.event,
                     sender_name: alert.sender_name,


### PR DESCRIPTION
Fetches alerts from OpenWeather One Call API 3.0 and announces them conversationally via Alexa. Alerts occurring within the next 3 days are filtered and announced at the end of the weather forecast.

Changes:
- Add Alert struct to deserialize OpenWeather alert data
- Create public WeatherAlert struct for cross-provider compatibility
- Implement filter_alerts() to show only relevant alerts (next 3 days)
- Update Alexa formatting to announce alerts naturally (e.g., "There is a winter storm warning from 7am tomorrow through 8pm Monday")
- Announce first 2 alerts with event name and time range
- Show remaining count if more than 2 alerts exist
- Update AccuWeather to return empty alerts for compatibility
- Update main.rs and lambda.rs to handle alerts from get_weather()
- Add comprehensive tests for alert formatting