### PR TITLE
Allow claude bot in code review workflow

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -34,6 +34,9 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
 
+          # Allow the claude bot to trigger this workflow
+          allowed_bots: "claude"
+
           # Optional: Specify model (defaults to Claude Sonnet 4, uncomment for Claude Opus 4)
           # model: "claude-opus-4-20250514"
 


### PR DESCRIPTION
Add allowed_bots configuration to permit PRs initiated by the claude bot user to pass through the Claude Code Review GitHub Action.