### PR TITLE
weather: consolidate HTTP plumbing and tighten ApiKey handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,17 +9,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
 
 [[package]]
-name = "again"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05802a5ad4d172eaf796f7047b42d0af9db513585d16d4169660a21613d34b93"
-dependencies = [
- "log",
- "rand 0.7.3",
- "wasm-timer",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -602,12 +591,6 @@ dependencies = [
 
 [[package]]
 name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
-
-[[package]]
-name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
@@ -1093,17 +1076,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.1.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fc3cb4d91f53b50155bdcfd23f6a4c39ae1969c2ae85982b135750cccaf5fce"
-dependencies = [
- "cfg-if",
- "libc",
- "wasi 0.9.0+wasi-snapshot-preview1",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
@@ -1111,7 +1083,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "wasm-bindgen",
 ]
 
@@ -1525,15 +1497,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "instant"
-version = "0.1.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0242819d153cba4b4b05a5a8f2a7e9bbf97b6055b2a002b395c96b5ff3c0222"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
 name = "ipnet"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1555,7 +1518,6 @@ checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 name = "jakesky"
 version = "0.1.0"
 dependencies = [
- "again",
  "anyhow",
  "aws-config",
  "aws-sdk-bedrockruntime",
@@ -1565,7 +1527,6 @@ dependencies = [
  "jluszcz_rust_utils",
  "lambda_runtime",
  "log",
- "reqwest",
  "rustls 0.23.40",
  "serde",
  "serde_json",
@@ -1780,7 +1741,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasi",
  "windows-sys 0.61.2",
 ]
 
@@ -1834,37 +1795,12 @@ checksum = "1a80800c0488c3a21695ea981a54918fbb37abf04f4d0720c453632255e2ff0e"
 
 [[package]]
 name = "parking_lot"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
-dependencies = [
- "instant",
- "lock_api",
- "parking_lot_core 0.8.6",
-]
-
-[[package]]
-name = "parking_lot"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
 dependencies = [
  "lock_api",
- "parking_lot_core 0.9.12",
-]
-
-[[package]]
-name = "parking_lot_core"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60a2cfe6f0ad2bfc16aefa463b497d5c7a5ecd44a23efa72aa342d90177356dc"
-dependencies = [
- "cfg-if",
- "instant",
- "libc",
- "redox_syscall 0.2.16",
- "smallvec",
- "winapi",
+ "parking_lot_core",
 ]
 
 [[package]]
@@ -1875,7 +1811,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall 0.5.18",
+ "redox_syscall",
  "smallvec",
  "windows-link",
 ]
@@ -1999,7 +1935,7 @@ dependencies = [
  "bytes",
  "getrandom 0.3.4",
  "lru-slab",
- "rand 0.9.4",
+ "rand",
  "ring",
  "rustc-hash",
  "rustls 0.23.40",
@@ -2042,35 +1978,12 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6a6b1679d49b24bbfe0c803429aa1874472f50d9b363131f0e89fc356b544d03"
-dependencies = [
- "getrandom 0.1.16",
- "libc",
- "rand_chacha 0.2.2",
- "rand_core 0.5.1",
- "rand_hc",
-]
-
-[[package]]
-name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha 0.9.0",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4c8ed856279c9737206bf725bf36935d8666ead7aa69b52be55af369d193402"
-dependencies = [
- "ppv-lite86",
- "rand_core 0.5.1",
+ "rand_chacha",
+ "rand_core",
 ]
 
 [[package]]
@@ -2080,16 +1993,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90bde5296fc891b0cef12a6d03ddccc162ce7b2aff54160af9338f8d40df6d19"
-dependencies = [
- "getrandom 0.1.16",
+ "rand_core",
 ]
 
 [[package]]
@@ -2102,30 +2006,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "rand_hc"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3129af7b92a17112d59ad498c6f81eaf463253766b90396d39ea7a39d6613c"
-dependencies = [
- "rand_core 0.5.1",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.2.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
-dependencies = [
- "bitflags 1.3.2",
-]
-
-[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -2370,7 +2256,7 @@ version = "3.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
@@ -2621,7 +2507,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "core-foundation 0.9.4",
  "system-configuration-sys",
 ]
@@ -2729,7 +2615,7 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot 0.12.5",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
  "socket2 0.6.3",
@@ -2814,7 +2700,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4cfcf7e2740e6fc6d4d688b4ef00650406bb94adf4731e43c096c3a19fe40840"
 dependencies = [
  "async-compression",
- "bitflags 2.11.1",
+ "bitflags",
  "bytes",
  "futures-core",
  "futures-util",
@@ -3006,12 +2892,6 @@ dependencies = [
 
 [[package]]
 name = "wasi"
-version = "0.9.0+wasi-snapshot-preview1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cccddf32554fecc6acb585f82a32a72e28b48f8c4c1883ddfeeeaa96f7d8e519"
-
-[[package]]
-name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
@@ -3081,21 +2961,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasm-timer"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
-dependencies = [
- "futures",
- "js-sys",
- "parking_lot 0.11.2",
- "pin-utils",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3125,22 +2990,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
-dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
-]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
 name = "winapi-util"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3148,12 +2997,6 @@ checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
  "windows-sys 0.61.2",
 ]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,6 @@ version = "0.1.0"
 edition = "2024"
 
 [dependencies]
-again = "0.1"
 anyhow = "1.0"
 aws-config = "1"
 aws-sdk-bedrockruntime = "1"
@@ -16,7 +15,6 @@ clap = { version = "4.5", features = ["env"] }
 jluszcz_rust_utils = { git = "https://github.com//jluszcz/rust-utils", features = ["query"] }
 lambda_runtime = "1.*"
 log = "0.4"
-reqwest = { version = "0.13", features = ["gzip", "json", "query"] }
 rustls = { version = "0.23", default-features = false }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,8 +1,9 @@
 #![recursion_limit = "256"]
 
+use anyhow::Context;
 use jakesky::ai::BedrockSummarizer;
 use jakesky::alert_summary;
-use jakesky::weather::{ApiKey, WeatherProvider, validate_coordinates};
+use jakesky::weather::{ApiKey, WeatherProvider};
 use jakesky::{APP_NAME, alexa};
 use jluszcz_rust_utils::cache::CacheMode;
 use jluszcz_rust_utils::lambda;
@@ -33,12 +34,10 @@ async fn function(event: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Er
 
     lambda::init(APP_NAME, module_path!(), false).await?;
 
-    let api_key = ApiKey::new(env::var("JAKESKY_API_KEY")?)?;
+    let api_key =
+        ApiKey::new(env::var("JAKESKY_API_KEY")?).context("JAKESKY_API_KEY is invalid")?;
     let latitude = env::var("JAKESKY_LATITUDE")?.parse()?;
     let longitude = env::var("JAKESKY_LONGITUDE")?.parse()?;
-
-    // Validate coordinates
-    validate_coordinates(latitude, longitude)?;
 
     let (weather, alerts) = WeatherProvider::OpenWeather
         .get_weather(CacheMode::Disabled, &api_key, latitude, longitude)

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,7 +2,7 @@ use anyhow::Result;
 use clap::{Arg, ArgAction, Command};
 use jakesky::ai::BedrockSummarizer;
 use jakesky::alert_summary;
-use jakesky::weather::{ApiKey, WeatherProvider, validate_coordinates};
+use jakesky::weather::{ApiKey, WeatherProvider};
 use jakesky::{APP_NAME, alexa};
 use jluszcz_rust_utils::cache::CacheMode;
 use jluszcz_rust_utils::{Verbosity, set_up_logger};
@@ -63,6 +63,7 @@ fn create_command() -> Command {
                 .required(true)
                 .env("JAKESKY_API_KEY")
                 .hide_env_values(true)
+                .value_parser(parse_api_key)
                 .help("API key to use with the weather provider"),
         )
         .arg(
@@ -78,12 +79,16 @@ fn create_command() -> Command {
         )
 }
 
+fn parse_api_key(s: &str) -> Result<ApiKey, String> {
+    ApiKey::new(s).map_err(|e| e.to_string())
+}
+
 fn args_from_matches(matches: clap::ArgMatches) -> Args {
     let verbosity = matches.get_count("verbosity").into();
     let cache_mode = matches.get_flag("use-cache").into();
     let latitude = *matches.get_one::<f64>("latitude").unwrap();
     let longitude = *matches.get_one::<f64>("longitude").unwrap();
-    let api_key = ApiKey::new(matches.get_one::<String>("api-key").cloned().unwrap()).unwrap();
+    let api_key = matches.get_one::<ApiKey>("api-key").cloned().unwrap();
     let provider = matches
         .get_one::<String>("provider")
         .and_then(|p| WeatherProvider::from_str(p).ok())
@@ -111,9 +116,6 @@ async fn main() -> Result<()> {
     let args = parse_args();
     set_up_logger(APP_NAME, module_path!(), args.verbosity)?;
     debug!("{args:?}");
-
-    // Validate coordinates early for better error messages
-    validate_coordinates(args.latitude, args.longitude)?;
 
     let (weather, alerts) = args
         .provider
@@ -182,7 +184,8 @@ mod tests {
                 Arg::new("api-key")
                     .short('a')
                     .long("api-key")
-                    .required(true),
+                    .required(true)
+                    .value_parser(parse_api_key),
             )
             .arg(
                 Arg::new("provider")

--- a/src/weather/accu_weather.rs
+++ b/src/weather/accu_weather.rs
@@ -1,15 +1,12 @@
-use crate::weather::{self, Weather, WeatherForecast};
-use again::RetryPolicy;
+use crate::weather::{ApiKey, Weather, WeatherForecast};
 use anyhow::{Context, Result, anyhow};
 use chrono::serde::ts_seconds;
 use chrono::{DateTime, Utc};
 use chrono_tz::Tz;
 use jluszcz_rust_utils::cache::{CacheMode, dated_cache_path, try_cached_query};
-use log::trace;
-use reqwest::Method;
-use serde::{Deserialize, Serialize};
+use jluszcz_rust_utils::query;
+use serde::Deserialize;
 use std::str::FromStr;
-use std::time::Duration;
 
 #[derive(Deserialize, Debug)]
 struct LocationResponse {
@@ -68,39 +65,21 @@ struct Temperature {
     value: f64,
 }
 
-impl TryFrom<(CurrentConditionsResponse, &str)> for Weather {
-    type Error = anyhow::Error;
-
-    fn try_from(value: (CurrentConditionsResponse, &str)) -> Result<Self, Self::Error> {
-        let (curr, timezone) = value;
-        let timezone = Tz::from_str(timezone).with_context(|| {
-            format!("Failed to parse timezone '{timezone}' from AccuWeather response")
-        })?;
-
-        Ok(Self {
-            timestamp: curr.timestamp.with_timezone(&timezone),
-            summary: normalize_weather(&curr.weather),
-            temp: curr.temp.imperial.value,
-            apparent_temp: curr.feels_like_temp.map(|t| t.imperial.value),
-        })
+fn current_to_weather(curr: CurrentConditionsResponse, timezone: Tz) -> Weather {
+    Weather {
+        timestamp: curr.timestamp.with_timezone(&timezone),
+        summary: normalize_weather(&curr.weather),
+        temp: curr.temp.imperial.value,
+        apparent_temp: curr.feels_like_temp.map(|t| t.imperial.value),
     }
 }
 
-impl TryFrom<(WeatherResponse, &str)> for Weather {
-    type Error = anyhow::Error;
-
-    fn try_from(value: (WeatherResponse, &str)) -> Result<Self, Self::Error> {
-        let (weather, timezone) = value;
-        let timezone = Tz::from_str(timezone).with_context(|| {
-            format!("Failed to parse timezone '{timezone}' from AccuWeather forecast response")
-        })?;
-
-        Ok(Self {
-            timestamp: weather.timestamp.with_timezone(&timezone),
-            summary: normalize_weather(&weather.weather),
-            temp: weather.temp.value,
-            apparent_temp: weather.feels_like_temp.map(|f| f.value),
-        })
+fn forecast_to_weather(weather: WeatherResponse, timezone: Tz) -> Weather {
+    Weather {
+        timestamp: weather.timestamp.with_timezone(&timezone),
+        summary: normalize_weather(&weather.weather),
+        temp: weather.temp.value,
+        apparent_temp: weather.feels_like_temp.map(|f| f.value),
     }
 }
 
@@ -110,67 +89,34 @@ fn normalize_weather(weather: &str) -> String {
         .replace("t-storms", "thunderstorms")
 }
 
-async fn http_get<T>(url: &str, params: &T) -> Result<String>
-where
-    T: Serialize + ?Sized,
-{
-    let retry_policy = RetryPolicy::exponential(Duration::from_millis(100))
-        .with_jitter(true)
-        .with_max_delay(Duration::from_secs(2))
-        .with_max_retries(3);
-
-    let response = retry_policy
-        .retry(|| {
-            weather::http_client()
-                .request(Method::GET, url)
-                .header("Accept", "application/json")
-                .header("Accept-Encoding", "gzip")
-                .query(params)
-                .send()
-        })
-        .await
-        .with_context(|| format!("Failed to make HTTP request to {url}"))?
-        .error_for_status()
-        .with_context(|| format!("HTTP request failed for {url}"))?
-        .text()
-        .await
-        .with_context(|| "Failed to read response body")?;
-
-    trace!("{response}");
-
-    Ok(response)
-}
-
-async fn query_location(api_key: &str, latitude: f64, longitude: f64) -> Result<String> {
-    http_get(
+async fn query_location(api_key: &ApiKey, latitude: f64, longitude: f64) -> Result<String> {
+    let q = format!("{latitude},{longitude}");
+    query::http_get(
         "http://dataservice.accuweather.com/locations/v1/cities/geoposition/search",
-        &[
-            ("apikey", api_key),
-            ("q", &format!("{latitude},{longitude}")),
-        ],
+        &[("apikey", api_key.as_str()), ("q", q.as_str())],
     )
     .await
 }
 
-async fn query_current_conditions(api_key: &str, location_id: &str) -> Result<String> {
-    http_get(
+async fn query_current_conditions(api_key: &ApiKey, location_id: &str) -> Result<String> {
+    query::http_get(
         &format!("http://dataservice.accuweather.com/currentconditions/v1/{location_id}"),
-        &[("apikey", api_key), ("details", "true")],
+        &[("apikey", api_key.as_str()), ("details", "true")],
     )
     .await
 }
 
-async fn query_weather(api_key: &str, location_id: &str) -> Result<String> {
-    http_get(
+async fn query_weather(api_key: &ApiKey, location_id: &str) -> Result<String> {
+    query::http_get(
         &format!("http://dataservice.accuweather.com/forecasts/v1/hourly/12hour/{location_id}"),
-        &[("apikey", api_key), ("details", "true")],
+        &[("apikey", api_key.as_str()), ("details", "true")],
     )
     .await
 }
 
 pub async fn get_weather(
     cache_mode: CacheMode,
-    api_key: &str,
+    api_key: &ApiKey,
     latitude: f64,
     longitude: f64,
 ) -> Result<WeatherForecast> {
@@ -191,6 +137,13 @@ pub async fn get_weather(
 
     let location: LocationResponse = serde_json::from_str(&location)
         .with_context(|| "Failed to parse location response from AccuWeather API")?;
+
+    let timezone = Tz::from_str(&location.timezone.name).with_context(|| {
+        format!(
+            "Failed to parse timezone '{}' from AccuWeather response",
+            location.timezone.name
+        )
+    })?;
 
     let current_conditions = try_cached_query(cache_mode, &current_conditions_cache_path, || {
         query_current_conditions(api_key, &location.id)
@@ -214,41 +167,37 @@ pub async fn get_weather(
         )
     })?;
 
-    let current = parse_current_conditions(&current_conditions, &location.timezone.name)
+    let current = parse_current_conditions(&current_conditions, timezone)
         .with_context(|| "Failed to parse current weather conditions")?;
-    let upcoming = parse_weather(&weather_data, &location.timezone.name)
+    let upcoming = parse_weather(&weather_data, timezone)
         .with_context(|| "Failed to parse weather forecast data")?;
 
     Ok(WeatherForecast {
-        timezone: current.timestamp.timezone(),
+        timezone,
         current,
         upcoming,
         alerts: Vec::new(), // AccuWeather alerts are not currently implemented
     })
 }
 
-fn parse_current_conditions(response: &str, timezone: &str) -> Result<Weather> {
+fn parse_current_conditions(response: &str, timezone: Tz) -> Result<Weather> {
     let response: Vec<CurrentConditionsResponse> = serde_json::from_str(response)
         .with_context(|| "Failed to deserialize current conditions JSON from AccuWeather")?;
-    let response = response
+    let curr = response
         .into_iter()
         .next()
         .ok_or_else(|| anyhow!("AccuWeather API returned empty current conditions array"))?;
-    (response, timezone).try_into()
+    Ok(current_to_weather(curr, timezone))
 }
 
-fn parse_weather(response: &str, timezone: &str) -> Result<Vec<Weather>> {
+fn parse_weather(response: &str, timezone: Tz) -> Result<Vec<Weather>> {
     let response: Vec<WeatherResponse> = serde_json::from_str(response)
         .with_context(|| "Failed to deserialize weather forecast JSON from AccuWeather")?;
 
-    let mut weather = Vec::new();
-    for (index, w) in response.into_iter().enumerate() {
-        weather.push((w, timezone).try_into().with_context(|| {
-            format!("Failed to convert weather entry {index} from AccuWeather")
-        })?);
-    }
-
-    Ok(weather)
+    Ok(response
+        .into_iter()
+        .map(|w| forecast_to_weather(w, timezone))
+        .collect())
 }
 
 #[cfg(test)]

--- a/src/weather/mod.rs
+++ b/src/weather/mod.rs
@@ -3,29 +3,34 @@ use chrono::{DateTime, Datelike, Timelike, Utc, Weekday};
 use chrono_tz::Tz;
 use jluszcz_rust_utils::cache::CacheMode;
 use log::{debug, trace};
-use reqwest::Client;
 use std::fmt;
 use std::str::FromStr;
-use std::sync::OnceLock;
-use std::time::Duration;
 
 pub mod accu_weather;
 pub mod open_weather;
+
+/// Minimum length for an API key. Soft sanity check to catch obvious
+/// configuration mistakes (e.g. empty or placeholder values), not a security
+/// guarantee — real provider keys are far longer than this.
+const MIN_API_KEY_LEN: usize = 8;
 
 /// A secure wrapper for API keys that prevents accidental logging
 #[derive(Clone)]
 pub struct ApiKey(String);
 
 impl ApiKey {
-    /// Creates a new ApiKey after basic validation
+    /// Creates a new ApiKey after sanity-checking the input.
+    ///
+    /// Rejects keys that are empty / whitespace-only, or shorter than
+    /// [`MIN_API_KEY_LEN`] characters.
     pub fn new(key: impl Into<String>) -> Result<Self> {
         let key = key.into();
         if key.trim().is_empty() {
             return Err(anyhow!("API key cannot be empty"));
         }
-        if key.len() < 8 {
+        if key.len() < MIN_API_KEY_LEN {
             return Err(anyhow!(
-                "API key appears to be too short (minimum 8 characters)"
+                "API key appears to be too short (minimum {MIN_API_KEY_LEN} characters)"
             ));
         }
         Ok(Self(key))
@@ -112,16 +117,15 @@ impl WeatherProvider {
         latitude: f64,
         longitude: f64,
     ) -> Result<(Vec<Weather>, Vec<WeatherAlert>)> {
-        // Validate coordinates before making API calls
         validate_coordinates(latitude, longitude)
             .with_context(|| format!("Invalid coordinates: lat={latitude}, lon={longitude}"))?;
 
         let weather = match self {
             Self::AccuWeather => {
-                accu_weather::get_weather(cache_mode, api_key.as_str(), latitude, longitude).await
+                accu_weather::get_weather(cache_mode, api_key, latitude, longitude).await
             }
             Self::OpenWeather => {
-                open_weather::get_weather(cache_mode, api_key.as_str(), latitude, longitude).await
+                open_weather::get_weather(cache_mode, api_key, latitude, longitude).await
             }
         }?;
         debug!("{weather:?}");
@@ -196,7 +200,7 @@ pub fn hours_of_interest(
 }
 
 /// Validates that latitude is within valid bounds (-90.0 to 90.0)
-pub fn validate_latitude(latitude: f64) -> Result<()> {
+fn validate_latitude(latitude: f64) -> Result<()> {
     if !(-90.0..=90.0).contains(&latitude) {
         return Err(anyhow!(
             "Latitude must be between -90.0 and 90.0 degrees, got: {}",
@@ -207,7 +211,7 @@ pub fn validate_latitude(latitude: f64) -> Result<()> {
 }
 
 /// Validates that longitude is within valid bounds (-180.0 to 180.0)
-pub fn validate_longitude(longitude: f64) -> Result<()> {
+fn validate_longitude(longitude: f64) -> Result<()> {
     if !(-180.0..=180.0).contains(&longitude) {
         return Err(anyhow!(
             "Longitude must be between -180.0 and 180.0 degrees, got: {}",
@@ -224,18 +228,35 @@ pub fn validate_coordinates(latitude: f64, longitude: f64) -> Result<()> {
     Ok(())
 }
 
-// Shared HTTP client with optimized configuration
-static HTTP_CLIENT: OnceLock<Client> = OnceLock::new();
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-pub fn http_client() -> &'static Client {
-    HTTP_CLIENT.get_or_init(|| {
-        Client::builder()
-            .timeout(Duration::from_secs(30))
-            .connect_timeout(Duration::from_secs(10))
-            .pool_idle_timeout(Duration::from_secs(90))
-            .pool_max_idle_per_host(10)
-            .gzip(true)
-            .build()
-            .expect("Failed to create HTTP client")
-    })
+    const SECRET: &str = "super-secret-key-value";
+
+    #[test]
+    fn api_key_debug_redacts_secret() {
+        let key = ApiKey::new(SECRET).unwrap();
+        let rendered = format!("{key:?}");
+        assert!(
+            !rendered.contains(SECRET),
+            "Debug output leaked API key: {rendered}"
+        );
+    }
+
+    #[test]
+    fn api_key_display_redacts_secret() {
+        let key = ApiKey::new(SECRET).unwrap();
+        let rendered = format!("{key}");
+        assert!(
+            !rendered.contains(SECRET),
+            "Display output leaked API key: {rendered}"
+        );
+    }
+
+    #[test]
+    fn api_key_as_str_returns_secret() {
+        let key = ApiKey::new(SECRET).unwrap();
+        assert_eq!(key.as_str(), SECRET);
+    }
 }

--- a/src/weather/open_weather.rs
+++ b/src/weather/open_weather.rs
@@ -1,16 +1,12 @@
-use crate::weather::{self, Weather, WeatherAlert, WeatherForecast};
-use again::RetryPolicy;
+use crate::weather::{ApiKey, Weather, WeatherAlert, WeatherForecast};
 use anyhow::{Context, Result, anyhow};
 use chrono::serde::ts_seconds;
-use chrono::{DateTime, TimeZone, Timelike, Utc};
+use chrono::{DateTime, TimeZone, Utc};
 use chrono_tz::Tz;
 use jluszcz_rust_utils::cache::{CacheMode, dated_cache_path, try_cached_query};
-use log::{debug, trace};
-use reqwest::Method;
+use jluszcz_rust_utils::query;
 use serde::Deserialize;
-use std::convert::{TryFrom, TryInto};
 use std::str::FromStr;
-use std::time::Duration;
 
 #[derive(Deserialize, Debug)]
 struct Response {
@@ -21,7 +17,7 @@ struct Response {
     alerts: Vec<Alert>,
 }
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug)]
 struct Alert {
     sender_name: String,
     event: String,
@@ -62,47 +58,35 @@ fn normalize_weather(weather: &str) -> String {
     .to_string()
 }
 
-impl TryFrom<&WeatherItem> for String {
-    type Error = anyhow::Error;
-
-    fn try_from(value: &WeatherItem) -> Result<Self, Self::Error> {
-        if value.weather.is_empty() {
-            return Err(anyhow!("Weather not found in {:?}", value));
-        }
-
-        let weather = value
-            .weather
-            .iter()
-            .map(|w| normalize_weather(&w.main))
-            .collect::<Vec<_>>();
-
-        Ok(if weather.len() == 1 {
-            weather.first().cloned().unwrap()
-        } else {
-            let (summary, second) = weather.split_at(weather.len() - 1);
-            summary.join(", ") + " and " + &second[0]
-        })
+fn weather_summary(item: &WeatherItem) -> Result<String> {
+    if item.weather.is_empty() {
+        return Err(anyhow!("Weather not found in {:?}", item));
     }
+
+    let parts: Vec<String> = item
+        .weather
+        .iter()
+        .map(|w| normalize_weather(&w.main))
+        .collect();
+
+    Ok(if parts.len() == 1 {
+        parts.into_iter().next().unwrap()
+    } else {
+        let (rest, last) = parts.split_at(parts.len() - 1);
+        rest.join(", ") + " and " + &last[0]
+    })
 }
 
-impl TryFrom<&(Tz, WeatherItem)> for Weather {
-    type Error = anyhow::Error;
+fn to_weather(tz: Tz, item: &WeatherItem) -> Result<Weather> {
+    let summary = weather_summary(item)
+        .with_context(|| "Failed to extract weather summary from OpenWeather data")?;
 
-    fn try_from(value: &(Tz, WeatherItem)) -> Result<Self, Self::Error> {
-        let (tz, weather) = value;
-
-        let timestamp = tz.from_utc_datetime(&weather.timestamp.naive_utc());
-        let summary = weather
-            .try_into()
-            .with_context(|| "Failed to extract weather summary from OpenWeather data")?;
-
-        Ok(Self {
-            timestamp: timestamp.with_timezone(tz),
-            summary,
-            temp: weather.temp,
-            apparent_temp: weather.apparent_temp,
-        })
-    }
+    Ok(Weather {
+        timestamp: tz.from_utc_datetime(&item.timestamp.naive_utc()),
+        summary,
+        temp: item.temp,
+        apparent_temp: item.apparent_temp,
+    })
 }
 
 fn filter_alerts(alerts: Vec<Alert>, timezone: Tz) -> Vec<WeatherAlert> {
@@ -131,50 +115,25 @@ fn filter_alerts(alerts: Vec<Alert>, timezone: Tz) -> Vec<WeatherAlert> {
         .collect()
 }
 
-impl TryFrom<Response> for Vec<Weather> {
-    type Error = anyhow::Error;
+fn parse_response(response: Response, timezone: Tz) -> Result<Vec<Weather>> {
+    let mut weather = Vec::with_capacity(1 + response.hourly.len());
+    weather.push(
+        to_weather(timezone, &response.current)
+            .with_context(|| "Failed to parse current weather from OpenWeather")?,
+    );
 
-    fn try_from(response: Response) -> Result<Self, Self::Error> {
-        let timezone = Tz::from_str(&response.timezone).with_context(|| {
-            format!(
-                "Failed to parse timezone '{}' from OpenWeather API",
-                response.timezone
-            )
-        })?;
-
-        let now = timezone.from_utc_datetime(&response.current.timestamp.naive_utc());
-
-        let mut weather = vec![
-            Weather::try_from(&(timezone, response.current))
-                .with_context(|| "Failed to parse current weather from OpenWeather")?,
-        ];
-
-        for (index, hourly_weather) in response.hourly.into_iter().enumerate() {
-            let hourly_weather =
-                Weather::try_from(&(timezone, hourly_weather)).with_context(|| {
-                    format!("Failed to parse hourly weather entry {index} from OpenWeather")
-                })?;
-
-            if hourly_weather.timestamp.date_naive() > now.date_naive() {
-                debug!("{:?} is no longer relevant", hourly_weather.timestamp);
-                break;
-            }
-
-            if hourly_weather.timestamp.hour() == now.hour() {
-                debug!("Skipping current hour: {:?}", hourly_weather.timestamp);
-                continue;
-            }
-
-            weather.push(hourly_weather);
-        }
-
-        Ok(weather)
+    for (index, hourly) in response.hourly.iter().enumerate() {
+        weather.push(to_weather(timezone, hourly).with_context(|| {
+            format!("Failed to parse hourly weather entry {index} from OpenWeather")
+        })?);
     }
+
+    Ok(weather)
 }
 
 pub async fn get_weather(
     cache_mode: CacheMode,
-    api_key: &str,
+    api_key: &ApiKey,
     latitude: f64,
     longitude: f64,
 ) -> Result<WeatherForecast> {
@@ -190,7 +149,7 @@ pub async fn get_weather(
         )
     })?;
 
-    let response: Response = serde_json::from_str(&response_str)
+    let mut response: Response = serde_json::from_str(&response_str)
         .with_context(|| "Failed to deserialize JSON response from OpenWeather API")?;
 
     let timezone = Tz::from_str(&response.timezone).with_context(|| {
@@ -200,56 +159,34 @@ pub async fn get_weather(
         )
     })?;
 
-    let alerts = filter_alerts(response.alerts.clone(), timezone);
+    let alerts = filter_alerts(std::mem::take(&mut response.alerts), timezone);
 
-    let mut weather: Vec<Weather> = response
-        .try_into()
+    let mut weather = parse_response(response, timezone)
         .with_context(|| "Failed to parse OpenWeather API response")?;
 
     Ok(WeatherForecast {
-        timezone: weather[0].timestamp.timezone(),
+        timezone,
         current: weather.remove(0),
         upcoming: weather,
         alerts,
     })
 }
 
-async fn query(api_key: &str, latitude: f64, longitude: f64) -> Result<String> {
-    let retry_policy = RetryPolicy::exponential(Duration::from_millis(100))
-        .with_jitter(true)
-        .with_max_delay(Duration::from_secs(2))
-        .with_max_retries(3);
-
-    // Since we only care about the current and hourly forecast for specific times, exclude some of the data in the response.
-    let response = retry_policy
-        .retry(|| {
-            weather::http_client()
-                .request(
-                    Method::GET,
-                    "https://api.openweathermap.org/data/3.0/onecall",
-                )
-                .header("Accept", "application/json")
-                .header("Accept-Encoding", "gzip")
-                .query(&[
-                    ("exclude", "minutely,daily"),
-                    ("units", "imperial"),
-                    ("appid", api_key),
-                    ("lat", &format!("{latitude}")),
-                    ("lon", &format!("{longitude}")),
-                ])
-                .send()
-        })
-        .await
-        .with_context(|| "Failed to make HTTP request to OpenWeather API")?
-        .error_for_status()
-        .with_context(|| "OpenWeather API returned an error status")?
-        .text()
-        .await
-        .with_context(|| "Failed to read OpenWeather API response body")?;
-
-    trace!("{response}");
-
-    Ok(response)
+async fn query(api_key: &ApiKey, latitude: f64, longitude: f64) -> Result<String> {
+    let lat = latitude.to_string();
+    let lon = longitude.to_string();
+    query::http_get(
+        "https://api.openweathermap.org/data/3.0/onecall",
+        &[
+            ("exclude", "minutely,daily"),
+            ("units", "imperial"),
+            ("appid", api_key.as_str()),
+            ("lat", &lat),
+            ("lon", &lon),
+        ],
+    )
+    .await
+    .with_context(|| "Failed to make HTTP request to OpenWeather API")
 }
 
 #[cfg(test)]
@@ -261,11 +198,10 @@ mod test {
 
     #[test]
     fn test_deserialize() -> Result<()> {
-        let response: Result<Response, _> = serde_json::from_str(EXAMPLE_API_RESPONSE);
-        assert!(response.is_ok());
-
-        let weathers: Result<Vec<Weather>> = response?.try_into();
-        assert!(weathers.is_ok());
+        let response: Response = serde_json::from_str(EXAMPLE_API_RESPONSE)?;
+        let timezone = Tz::from_str(&response.timezone)?;
+        let weathers = parse_response(response, timezone)?;
+        assert!(!weathers.is_empty());
 
         Ok(())
     }


### PR DESCRIPTION
- Use jluszcz_rust_utils::query::http_get in both providers; drop the local http_client static and per-provider retry/header boilerplate (and the again + reqwest direct deps).
- Thread &ApiKey through provider get_weather so the redaction guarantee holds beyond the public boundary; only call .as_str() at the actual HTTP query site.
- Validate coordinates once in WeatherProvider::get_weather; drop the redundant calls in main and lambda.
- Replace TryFrom<&(Tz, WeatherItem)> / TryFrom<&WeatherItem> for String / TryFrom<(WeatherResponse, &str)> with named helper functions for clearer call sites.
- Make OpenWeather response parsing parse-only (filtering already lives in WeatherProvider::get_weather) and parse Tz once.
- Use a clap value_parser for ApiKey so validation failures surface as clap errors instead of an unwrap panic.