### PR TITLE
cleanup: dedupe clap command, use HTTPS for AccuWeather, simplify Bed…

### DIFF
--- a/src/ai.rs
+++ b/src/ai.rs
@@ -1,10 +1,12 @@
 //! Bedrock-backed fallback for summarizing vague weather alerts when
 //! rule-based extraction in `alert_summary` doesn't find a phenomenon.
 
+use crate::alert_summary::needs_llm_fallback;
+use crate::weather::WeatherAlert;
 use anyhow::{Result, anyhow};
 use aws_config::ConfigLoader;
 use aws_sdk_bedrockruntime::types::{ContentBlock, ConversationRole, Message};
-use log::{debug, warn};
+use log::debug;
 use std::time::Duration;
 
 const DEFAULT_MODEL_ID: &str = "us.amazon.nova-2-lite-v1:0";
@@ -30,24 +32,16 @@ pub struct BedrockSummarizer {
 }
 
 impl BedrockSummarizer {
-    pub async fn from_env() -> Result<Self> {
+    /// Build a client from the ambient AWS configuration, honoring the
+    /// `BEDROCK_MODEL_ID` env var override. Credential or connectivity
+    /// problems surface later as per-call errors, which callers already
+    /// handle by falling back to the event name.
+    pub async fn from_env() -> Self {
         let config = ConfigLoader::default().load().await;
         let client = aws_sdk_bedrockruntime::Client::new(&config);
         let model_id =
             std::env::var("BEDROCK_MODEL_ID").unwrap_or_else(|_| DEFAULT_MODEL_ID.to_owned());
-        Ok(Self { client, model_id })
-    }
-
-    /// Initialize a summarizer; return None (with a warning) if Bedrock is
-    /// unreachable or not configured, so the caller can fall back gracefully.
-    pub async fn try_init() -> Option<Self> {
-        Self::from_env()
-            .await
-            .map_err(|e| {
-                warn!("Bedrock unavailable, skipping alert summarization fallback: {e}");
-                e
-            })
-            .ok()
+        Self { client, model_id }
     }
 
     async fn invoke(&self, event: &str, description: &str) -> Result<String> {
@@ -94,6 +88,16 @@ impl BedrockSummarizer {
 
         debug!("Bedrock summary for {event:?}: {text:?}");
         Ok(text)
+    }
+}
+
+/// Build a summarizer only when some alert actually needs the LLM fallback,
+/// so callers don't pay the AWS config/credential load otherwise.
+pub async fn summarizer_for(alerts: &[WeatherAlert]) -> Option<BedrockSummarizer> {
+    if needs_llm_fallback(alerts) {
+        Some(BedrockSummarizer::from_env().await)
+    } else {
+        None
     }
 }
 

--- a/src/alert_summary.rs
+++ b/src/alert_summary.rs
@@ -220,8 +220,8 @@ mod test {
 
     #[test]
     fn word_boundary_avoids_heat_false_positives() {
-        // "preheat" / "heating" — wait, "heating" starts with "heat" so it
-        // would match. We accept that; reject true false positives instead.
+        // contains_word matches by word prefix, so inflections like "heating"
+        // still match "heat" by design; "preheat" must not.
         assert_eq!(
             extract_phenomenon("The oven preheat cycle is unrelated"),
             None

--- a/src/alexa.rs
+++ b/src/alexa.rs
@@ -71,33 +71,28 @@ async fn to_forecast<S: AlertSummarize>(
     alerts: Vec<WeatherAlert>,
     summarizer: Option<&S>,
 ) -> Result<Vec<String>> {
-    if weather.is_empty() {
+    let [current, upcoming @ ..] = weather.as_slice() else {
         return Err(anyhow!("Weather cannot be empty"));
-    }
+    };
 
     let mut forecast = Vec::with_capacity(weather.len());
 
-    forecast.push(format!(
-        "It's currently {}.",
-        speakable_weather(weather.first().unwrap())
-    ));
+    forecast.push(format!("It's currently {}.", speakable_weather(current)));
 
-    for w in weather.iter().skip(1).take(weather.len().saturating_sub(2)) {
-        forecast.push(format!(
-            "At {}, it will be {}.",
-            speakable_timestamp(&w.timestamp),
-            speakable_weather(w)
-        ));
-    }
+    if let [middle @ .., last] = upcoming {
+        for w in middle {
+            forecast.push(format!(
+                "At {}, it will be {}.",
+                speakable_timestamp(&w.timestamp),
+                speakable_weather(w)
+            ));
+        }
 
-    if weather.len() > 1
-        && let Some(w) = weather.last()
-    {
         forecast.push(format!(
             "{} {} it will be {}.",
-            if weather.len() > 2 { "And at" } else { "At" },
-            speakable_timestamp(&w.timestamp),
-            speakable_weather(w),
+            if middle.is_empty() { "At" } else { "And at" },
+            speakable_timestamp(&last.timestamp),
+            speakable_weather(last),
         ));
     }
 
@@ -118,12 +113,12 @@ fn speakable_timestamp(timestamp: &DateTime<Tz>) -> String {
 
 fn speakable_weather(weather: &Weather) -> String {
     let temp = weather.apparent_temp.unwrap_or(weather.temp) as i64;
-    inner_speakable_weather(temp, &weather.summary)
+    format_temp_and_summary(temp, &weather.summary)
 }
 
-fn inner_speakable_weather(temp: i64, summary: &str) -> String {
+fn format_temp_and_summary(temp: i64, summary: &str) -> String {
     format!(
-        "{:.0}{} and {}",
+        "{}{} and {}",
         temp.abs(),
         if temp < 0 { " below" } else { "" },
         summary
@@ -223,8 +218,8 @@ mod test {
 
     #[test]
     fn test_speakable_weather() {
-        assert!(inner_speakable_weather(72, "foo").starts_with("72 and"));
-        assert!(inner_speakable_weather(-72, "foo").starts_with("72 below and"));
+        assert!(format_temp_and_summary(72, "foo").starts_with("72 and"));
+        assert!(format_temp_and_summary(-72, "foo").starts_with("72 below and"));
     }
 
     #[tokio::test]

--- a/src/lambda.rs
+++ b/src/lambda.rs
@@ -1,8 +1,7 @@
 #![recursion_limit = "256"]
 
 use anyhow::Context;
-use jakesky::ai::BedrockSummarizer;
-use jakesky::alert_summary;
+use jakesky::ai;
 use jakesky::weather::{ApiKey, WeatherProvider};
 use jakesky::{APP_NAME, alexa};
 use jluszcz_rust_utils::cache::CacheMode;
@@ -19,7 +18,7 @@ async fn main() -> Result<(), lambda_runtime::Error> {
     Ok(())
 }
 
-fn is_warmup_event(event: Value) -> bool {
+fn is_warmup_event(event: &Value) -> bool {
     "Scheduled Event"
         == event
             .get("detail-type")
@@ -28,7 +27,7 @@ fn is_warmup_event(event: Value) -> bool {
 }
 
 async fn function(event: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Error> {
-    if is_warmup_event(event.payload) {
+    if is_warmup_event(&event.payload) {
         return Ok(json!({}));
     }
 
@@ -39,15 +38,11 @@ async fn function(event: LambdaEvent<Value>) -> Result<Value, lambda_runtime::Er
     let latitude = env::var("JAKESKY_LATITUDE")?.parse()?;
     let longitude = env::var("JAKESKY_LONGITUDE")?.parse()?;
 
-    let (weather, alerts) = WeatherProvider::OpenWeather
+    let report = WeatherProvider::OpenWeather
         .get_weather(CacheMode::Disabled, &api_key, latitude, longitude)
         .await?;
 
-    let summarizer = if alert_summary::needs_llm_fallback(&alerts) {
-        BedrockSummarizer::try_init().await
-    } else {
-        None
-    };
+    let summarizer = ai::summarizer_for(&report.alerts).await;
 
-    Ok(alexa::forecast(weather, alerts, summarizer.as_ref()).await?)
+    Ok(alexa::forecast(report.weather, report.alerts, summarizer.as_ref()).await?)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,6 @@
 use anyhow::Result;
 use clap::{Arg, ArgAction, Command};
-use jakesky::ai::BedrockSummarizer;
-use jakesky::alert_summary;
+use jakesky::ai;
 use jakesky::weather::{ApiKey, WeatherProvider};
 use jakesky::{APP_NAME, alexa};
 use jluszcz_rust_utils::cache::CacheMode;
@@ -21,7 +20,7 @@ struct Args {
 
 fn create_command() -> Command {
     Command::new("JakeSky-rs")
-        .version("0.1")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Jacob Luszcz")
         .arg(
             Arg::new("verbosity")
@@ -70,17 +69,18 @@ fn create_command() -> Command {
             Arg::new("provider")
                 .short('p')
                 .long("provider")
-                .value_parser([
-                    WeatherProvider::AccuWeather.id(),
-                    WeatherProvider::OpenWeather.id(),
-                ])
-                .default_value("openweather")
-                .help("Which weather provider to use"),
+                .value_parser(parse_provider)
+                .default_value(WeatherProvider::OpenWeather.id())
+                .help("Which weather provider to use (accuweather or openweather)"),
         )
 }
 
 fn parse_api_key(s: &str) -> Result<ApiKey, String> {
     ApiKey::new(s).map_err(|e| e.to_string())
+}
+
+fn parse_provider(s: &str) -> Result<WeatherProvider, String> {
+    WeatherProvider::from_str(s).map_err(|e| e.to_string())
 }
 
 fn args_from_matches(matches: clap::ArgMatches) -> Args {
@@ -89,10 +89,7 @@ fn args_from_matches(matches: clap::ArgMatches) -> Args {
     let latitude = *matches.get_one::<f64>("latitude").unwrap();
     let longitude = *matches.get_one::<f64>("longitude").unwrap();
     let api_key = matches.get_one::<ApiKey>("api-key").cloned().unwrap();
-    let provider = matches
-        .get_one::<String>("provider")
-        .and_then(|p| WeatherProvider::from_str(p).ok())
-        .unwrap();
+    let provider = *matches.get_one::<WeatherProvider>("provider").unwrap();
 
     Args {
         verbosity,
@@ -117,7 +114,7 @@ async fn main() -> Result<()> {
     set_up_logger(APP_NAME, module_path!(), args.verbosity)?;
     debug!("{args:?}");
 
-    let (weather, alerts) = args
+    let report = args
         .provider
         .get_weather(
             args.cache_mode,
@@ -127,13 +124,9 @@ async fn main() -> Result<()> {
         )
         .await?;
 
-    let summarizer = if alert_summary::needs_llm_fallback(&alerts) {
-        BedrockSummarizer::try_init().await
-    } else {
-        None
-    };
+    let summarizer = ai::summarizer_for(&report.alerts).await;
 
-    alexa::forecast(weather, alerts, summarizer.as_ref()).await?;
+    alexa::forecast(report.weather, report.alerts, summarizer.as_ref()).await?;
 
     Ok(())
 }
@@ -154,49 +147,14 @@ mod tests {
         ]
     }
 
-    // Test command without env var support for predictable testing
+    /// The real command with env-var support stripped, so ambient JAKESKY_*
+    /// variables can't leak into tests.
     fn create_test_command() -> Command {
-        Command::new("JakeSky-rs")
-            .version("0.1")
-            .author("Jacob Luszcz")
-            .arg(Arg::new("verbosity").short('v').action(ArgAction::Count))
-            .arg(
-                Arg::new("use-cache")
-                    .short('c')
-                    .long("cache")
-                    .action(ArgAction::SetTrue),
-            )
-            .arg(
-                Arg::new("latitude")
-                    .long("latitude")
-                    .alias("lat")
-                    .required(true)
-                    .value_parser(clap::value_parser!(f64)),
-            )
-            .arg(
-                Arg::new("longitude")
-                    .long("longitude")
-                    .alias("long")
-                    .required(true)
-                    .value_parser(clap::value_parser!(f64)),
-            )
-            .arg(
-                Arg::new("api-key")
-                    .short('a')
-                    .long("api-key")
-                    .required(true)
-                    .value_parser(parse_api_key),
-            )
-            .arg(
-                Arg::new("provider")
-                    .short('p')
-                    .long("provider")
-                    .value_parser([
-                        WeatherProvider::AccuWeather.id(),
-                        WeatherProvider::OpenWeather.id(),
-                    ])
-                    .default_value("openweather"),
-            )
+        ["latitude", "longitude", "api-key"]
+            .into_iter()
+            .fold(create_command(), |command, name| {
+                command.mut_arg(name, |arg| arg.env(None::<&'static str>))
+            })
     }
 
     fn parse_args_from(args: &[&str]) -> Result<Args, clap::Error> {

--- a/src/weather/accu_weather.rs
+++ b/src/weather/accu_weather.rs
@@ -92,7 +92,7 @@ fn normalize_weather(weather: &str) -> String {
 async fn query_location(api_key: &ApiKey, latitude: f64, longitude: f64) -> Result<String> {
     let q = format!("{latitude},{longitude}");
     query::http_get(
-        "http://dataservice.accuweather.com/locations/v1/cities/geoposition/search",
+        "https://dataservice.accuweather.com/locations/v1/cities/geoposition/search",
         &[("apikey", api_key.as_str()), ("q", q.as_str())],
     )
     .await
@@ -100,7 +100,7 @@ async fn query_location(api_key: &ApiKey, latitude: f64, longitude: f64) -> Resu
 
 async fn query_current_conditions(api_key: &ApiKey, location_id: &str) -> Result<String> {
     query::http_get(
-        &format!("http://dataservice.accuweather.com/currentconditions/v1/{location_id}"),
+        &format!("https://dataservice.accuweather.com/currentconditions/v1/{location_id}"),
         &[("apikey", api_key.as_str()), ("details", "true")],
     )
     .await
@@ -108,7 +108,7 @@ async fn query_current_conditions(api_key: &ApiKey, location_id: &str) -> Result
 
 async fn query_weather(api_key: &ApiKey, location_id: &str) -> Result<String> {
     query::http_get(
-        &format!("http://dataservice.accuweather.com/forecasts/v1/hourly/12hour/{location_id}"),
+        &format!("https://dataservice.accuweather.com/forecasts/v1/hourly/12hour/{location_id}"),
         &[("apikey", api_key.as_str()), ("details", "true")],
     )
     .await

--- a/src/weather/mod.rs
+++ b/src/weather/mod.rs
@@ -96,7 +96,14 @@ pub struct WeatherForecast {
     pub alerts: Vec<WeatherAlert>,
 }
 
+/// A forecast filtered down to the hours worth announcing, plus any active alerts.
 #[derive(Debug)]
+pub struct WeatherReport {
+    pub weather: Vec<Weather>,
+    pub alerts: Vec<WeatherAlert>,
+}
+
+#[derive(Debug, Clone, Copy)]
 pub enum WeatherProvider {
     AccuWeather,
     OpenWeather,
@@ -116,7 +123,7 @@ impl WeatherProvider {
         api_key: &ApiKey,
         latitude: f64,
         longitude: f64,
-    ) -> Result<(Vec<Weather>, Vec<WeatherAlert>)> {
+    ) -> Result<WeatherReport> {
         validate_coordinates(latitude, longitude)
             .with_context(|| format!("Invalid coordinates: lat={latitude}, lon={longitude}"))?;
 
@@ -156,7 +163,10 @@ impl WeatherProvider {
             }
         }
 
-        Ok((filtered, alerts))
+        Ok(WeatherReport {
+            weather: filtered,
+            alerts,
+        })
     }
 }
 


### PR DESCRIPTION
…rock init

- main: tests reuse the real create_command() with env support stripped via mut_arg, instead of maintaining a drift-prone copy; provider parses directly into WeatherProvider; CLI version comes from CARGO_PKG_VERSION
- accu_weather: query endpoints over HTTPS so the API key is not sent in cleartext
- ai: BedrockSummarizer::from_env is infallible (no failure case existed), removing try_init's unreachable error path; new summarizer_for helper replaces duplicated bootstrapping in main and lambda
- weather: get_weather returns a named WeatherReport instead of a tuple
- alexa: to_forecast uses slice patterns instead of skip/take arithmetic; rename inner_speakable_weather to format_temp_and_summary